### PR TITLE
Disable eslint in generated file

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = {
       var file = fs.readFileSync(this.variablesFile, 'utf8');
       if (file) {
         sassVariables = getVariables(file);
-        var utilObject = `/* jshint ignore:start */\n// DON'T UPDATE THIS FILE MANUALLY, IT IS AUTO-GENERATED.\nconst sassVariables = JSON.parse(\`${JSON.stringify(sassVariables)}\`);\n\nexport default sassVariables;\n/* jshint ignore:end */`;
+        var utilObject = `/* eslint-disable */\n/* jshint ignore:start */\n// DON'T UPDATE THIS FILE MANUALLY, IT IS AUTO-GENERATED.\nconst sassVariables = JSON.parse(\`${JSON.stringify(sassVariables)}\`);\n\nexport default sassVariables;\n/* jshint ignore:end */`;
         try {
           outputFile = fs.readFileSync(outputPath, 'utf8');
         } catch(error) {}


### PR DESCRIPTION
Hello!

Thanks for this addon - it's exactly what I was looking for.

The generated file doesn't pass our eslint rules, so I added `eslint-disable` to the top of the generated output, similar to how js-hint is disabled. Please let me know if you need anything from me to help get this merged.

Thanks!