### PR TITLE
build sass-variables.js in preBuild, not postBuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = {
     this.appDir = this.app.options.appDir || 'app';
     this.variablesFile = this.app.options.sassVariables || null;
   },
-  postBuild: function(result) {
+  preBuild: function(result) {
     if (this.variablesFile) {
       var outputPath = this.appDir + '/utils/sass-variables.js';
       var sassVariables = null;


### PR DESCRIPTION
generate sass-variables.js before the build so it will be included in the dist output

building in postBuild doesn't work for CI:
- run ember test
- builds project to dist
- generates utils/sass-variables.js
- runs tests with code from dist, but utils/sass-variables.js not in that build because it didn't exist yet

it works for development (with `ember server`) because touching the file causes a rebuild
it works for production if a previous build (`ember test`) created the file